### PR TITLE
Provide option for localstorage user store (non-default for oidc lib)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,5 @@ pom.xml
 .rebel_readline_history
 resources/public/cljs-out/
 .clj-kondo/.cache
+.DS_Store
 

--- a/README.md
+++ b/README.md
@@ -13,16 +13,18 @@ Re-frame fx, event handlers and subscriptions are provided to allow interactive 
 
 Re-oidc requires a map of configuration options:
 
-| key                    | type     | default   | description                                                          |
-| -------------          | -------  | --------- | ----------------------------------------------------------------     |
-| `:auto-login`          | boolean  | false     | If no logged-in user is found, automatically initiate OIDC login     |
-| `:on-login-success`    | callback | none      | Action to perform after a login redirect is processed                |
-| `:on-login-failure`    | callback | none      | Action to perform after a login redirect failure                     |
-| `:on-logout-success`   | callback | none      | Action to perform after a logout redirect is processed               |
-| `:on-logout-failure`   | callback | none      | Action to perform after a logout redirect failure                    |
-| `:on-get-user-success` | callback | none      | Action to perform when an active logged-in user is found on init     |
-| `:on-get-user-failure` | callback | none      | Action to perform when an active logged-in user is not found on init |
-| `:oidc-config`         | map      | none      | The configuration for oidc-client-js as a clojure map.               |
+| key                    | type     | default          | description                                                                                             |
+| -------------          | -------  | ---------        | ----------------------------------------------------------------                                        |
+| `:auto-login`          | boolean  | false            | If no logged-in user is found, automatically initiate OIDC login                                        |
+| `:on-login-success`    | callback | none             | Action to perform after a login redirect is processed                                                   |
+| `:on-login-failure`    | callback | none             | Action to perform after a login redirect failure                                                        |
+| `:on-logout-success`   | callback | none             | Action to perform after a logout redirect is processed                                                  |
+| `:on-logout-failure`   | callback | none             | Action to perform after a logout redirect failure                                                       |
+| `:on-get-user-success` | callback | none             | Action to perform when an active logged-in user is found on init                                        |
+| `:on-get-user-failure` | callback | none             | Action to perform when an active logged-in user is not found on init                                    |
+| `:oidc-config`         | map      | none             | The configuration for oidc-client-js as a clojure map.                                                  |
+| `:state-store`         | keyword  | :local-storage   | Where `oidc-client-js` keeps the login callback state                                                   |
+| `:user-store`          | keyword  | :session-storage | Where `oidc-client-js` keeps the user state. Set to `:local-storage` to persist across tabs/new windows |
 
 ### Callbacks
 

--- a/src/dev/com/yetanalytics/re_oidc/demo.cljs
+++ b/src/dev/com/yetanalytics/re_oidc/demo.cljs
@@ -52,6 +52,7 @@
           ;; Initialize OIDC from the remote config
           [::re-oidc/init
            (assoc static-config
+                  :user-store :local-storage
                   ;; These config options are passed directly to the OIDC client
                   :oidc-config
                   config)]]]}))

--- a/src/test/com/yetanalytics/re_oidc_test.cljs
+++ b/src/test/com/yetanalytics/re_oidc_test.cljs
@@ -130,7 +130,10 @@
             [nil nil]))))
   (testing "with login callback"
     (is (= {:db {::re-oidc/status :init},
-            :fx [[::re-oidc/init-fx {:config {}}]
+            :fx [[::re-oidc/init-fx
+                  {:config {}
+                   :state-store :local-storage
+                   :user-store :session-storage}]
                  [::re-oidc/signin-redirect-callback-fx
                   {:query-string "?foo=bar",
                    :on-success [::success],
@@ -144,7 +147,10 @@
               :on-login-failure [::failure]}]))))
   (testing "with logout callback"
     (is (= {:db {::re-oidc/status :init},
-            :fx [[::re-oidc/init-fx {:config {}}]
+            :fx [[::re-oidc/init-fx
+                  {:config {}
+                   :state-store :local-storage
+                   :user-store :session-storage}]
                  [::re-oidc/signout-redirect-callback-fx
                   {:on-success [::success],
                    :on-failure [::failure]}]]}
@@ -156,7 +162,10 @@
               :on-logout-failure [::failure]}]))))
   (testing "with no callback"
     (is (= {:db {::re-oidc/status :init},
-            :fx [[::re-oidc/init-fx {:config {}}]
+            :fx [[::re-oidc/init-fx
+                  {:config {}
+                   :state-store :local-storage
+                   :user-store :session-storage}]
                  [::re-oidc/get-user-fx
                   {:auto-login false,
                    :on-success [::success],


### PR DESCRIPTION
By default `oidc-js` stores the user in session storage, meaning that logins do not work across tabs. Here we add options to the init handler for choosing both the `:state-store` and `:user-store` with the keys `:session-storage` or `:local-storage` respectively. See the demo change which specifies `:local-storage` and thus persists across tabs.
