### PR TITLE
Uri absolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,19 @@ Re-frame fx, event handlers and subscriptions are provided to allow interactive 
 
 Re-oidc requires a map of configuration options:
 
-| key                    | type     | default          | description                                                                                             |
-| -------------          | -------  | ---------        | ----------------------------------------------------------------                                        |
-| `:auto-login`          | boolean  | false            | If no logged-in user is found, automatically initiate OIDC login                                        |
-| `:on-login-success`    | callback | none             | Action to perform after a login redirect is processed                                                   |
-| `:on-login-failure`    | callback | none             | Action to perform after a login redirect failure                                                        |
-| `:on-logout-success`   | callback | none             | Action to perform after a logout redirect is processed                                                  |
-| `:on-logout-failure`   | callback | none             | Action to perform after a logout redirect failure                                                       |
-| `:on-get-user-success` | callback | none             | Action to perform when an active logged-in user is found on init                                        |
-| `:on-get-user-failure` | callback | none             | Action to perform when an active logged-in user is not found on init                                    |
-| `:oidc-config`         | map      | none             | The configuration for oidc-client-js as a clojure map.                                                  |
-| `:state-store`         | keyword  | :local-storage   | Where `oidc-client-js` keeps the login callback state                                                   |
-| `:user-store`          | keyword  | :session-storage | Where `oidc-client-js` keeps the user state. Set to `:local-storage` to persist across tabs/new windows |
+| key                        | type     | default          | description                                                                                             |
+| -------------              | -------  | ---------        | ----------------------------------------------------------------                                        |
+| `:auto-login`              | boolean  | false            | If no logged-in user is found, automatically initiate OIDC login                                        |
+| `:on-login-success`        | callback | none             | Action to perform after a login redirect is processed                                                   |
+| `:on-login-failure`        | callback | none             | Action to perform after a login redirect failure                                                        |
+| `:on-logout-success`       | callback | none             | Action to perform after a logout redirect is processed                                                  |
+| `:on-logout-failure`       | callback | none             | Action to perform after a logout redirect failure                                                       |
+| `:on-get-user-success`     | callback | none             | Action to perform when an active logged-in user is found on init                                        |
+| `:on-get-user-failure`     | callback | none             | Action to perform when an active logged-in user is not found on init                                    |
+| `:oidc-config`             | map      | none             | The configuration for oidc-client-js as a clojure map.                                                  |
+| `:redirect-uri-absolution` | boolean  | false            | Whether to expand relative redirect URIs to absolute with window.location                               |
+| `:state-store`             | keyword  | :local-storage   | Where `oidc-client-js` keeps the login callback state                                                   |
+| `:user-store`              | keyword  | :session-storage | Where `oidc-client-js` keeps the user state. Set to `:local-storage` to persist across tabs/new windows |
 
 ### Callbacks
 

--- a/src/lib/com/yetanalytics/re_oidc.cljs
+++ b/src/lib/com/yetanalytics/re_oidc.cljs
@@ -330,10 +330,12 @@
                              on-get-user-success
                              on-get-user-failure
                              state-store
-                             user-store]
+                             user-store
+                             redirect-uri-absolution]
                       :or {auto-login false
                            state-store :local-storage
-                           user-store :session-storage}}]]
+                           user-store :session-storage
+                           redirect-uri-absolution false}}]]
   (if status
     {}
     {:db (-> db
@@ -341,7 +343,9 @@
              (dissoc ::callback
                      ::login-query-string))
      :fx [[::init-fx
-           {:config oidc-config
+           {:config (cond-> oidc-config
+                      redirect-uri-absolution
+                      u/absolve-redirect-uris)
             :state-store state-store
             :user-store user-store}]
           (case ?callback

--- a/src/test/com/yetanalytics/re_oidc/util_test.cljs
+++ b/src/test/com/yetanalytics/re_oidc/util_test.cljs
@@ -4,7 +4,9 @@
    [com.yetanalytics.re-oidc.util :refer [dispatch-cb
                                           cb-fn-or-dispatch
                                           js-error->clj
-                                          expired?]]
+                                          expired?
+                                          absolve-uri
+                                          absolve-redirect-uris]]
    [re-frame.core :as re-frame]))
 
 (deftest dispatch-cb-test
@@ -59,3 +61,24 @@
            .getTime
            (quot 1000)
            (+ 86400)))))))
+
+(deftest absolve-uri-test
+  (testing "Converts relative to absolute"
+    (is
+     (= "http://localhost:9500/foo"
+        (absolve-uri "/foo")))))
+
+(deftest absolve-redirect-uris-test
+  (testing "Converts relative uri keys (kw or string) to absolute"
+    (is
+     (= {:redirect_uri "http://localhost:9500/foo"
+         "redirect_uri" "http://localhost:9500/bar"
+         :post_logout_redirect_uri "http://localhost:9500/baz"
+         "post_logout_redirect_uri" "http://localhost:9500/quxx"
+         :something_else "/fizz"}
+        (absolve-redirect-uris
+         {:redirect_uri "/foo"
+          "redirect_uri" "/bar"
+          :post_logout_redirect_uri "/baz"
+          "post_logout_redirect_uri" "/quxx"
+          :something_else "/fizz"})))))


### PR DESCRIPTION
If `:redirect-uri-absolution` is `true`, expand redirect URI paths like `/login-callback` to `<origin>/login-callback`.