### PR TITLE
Fix broken JS interop due to optimizations

### DIFF
--- a/src/lib/com/yetanalytics/re_oidc.cljs
+++ b/src/lib/com/yetanalytics/re_oidc.cljs
@@ -43,7 +43,7 @@
   [^UserManager user-manager
    {:keys [on-user-loaded
            on-user-unloaded]}]
-  (doto user-manager.events
+  (doto (.-events ^js user-manager)
     (.addUserLoaded
      (cond-> (u/dispatch-cb [::user-loaded])
        on-user-loaded


### PR DESCRIPTION
Using the library with shadow-cljs and advanced compilation caused JS interop to break, because the compiler renamed fields and property `events` of `UserManager` could not be accessed any more.
This PR fixes this interop issue by adding a compiler type hint.
Also the property access was using a method is considered unsupported by shadow-cljs, which is why I changed it.