### PR TITLE
Replace oidc-client with oidc-client-ts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup CI Environment
-      uses: yetanalytics/actions/setup-env@v0.0.4
+      uses: yetanalytics/action-setup-env@v2
 
     - name: Cache Deps
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,13 +11,13 @@ jobs:
     timeout-minutes: 5
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup CD Environment
-      uses: yetanalytics/actions/setup-env@v0.0.4
+      uses: yetanalytics/action-setup-env@v2
 
     - name: Cache Deps
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2
@@ -37,7 +37,7 @@ jobs:
       run: echo version=${GITHUB_REF#refs\/tags\/v} >> $GITHUB_OUTPUT
 
     - name: Build and deploy to Clojars
-      uses: yetanalytics/actions/deploy-clojars@v0.0.4
+      uses: yetanalytics/action-deploy-clojars@v2
       with:
           artifact-id: 're-oidc'
           src-dirs: '["src/lib"]'

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ pom.xml
 .cpcache/
 .rebel_readline_history
 resources/public/cljs-out/
+.calva/
 .clj-kondo/.cache
+.cljs_node_repl/
+.lsp/
 .DS_Store
-

--- a/README.md
+++ b/README.md
@@ -3,11 +3,33 @@
 [![CI](https://github.com/yetanalytics/re-oidc/actions/workflows/ci.yml/badge.svg)](https://github.com/yetanalytics/re-oidc/actions/workflows/ci.yml)
 [![Clojars Version](https://img.shields.io/clojars/v/com.yetanalytics/re-oidc)](https://clojars.org/com.yetanalytics/re-oidc)
 
-A wrapper for [oidc-client-js](https://github.com/IdentityModel/oidc-client-js) providing [OIDC](https://openid.net/specs/openid-connect-core-1_0.html) support for re-frame + reagent applications in cljs. Inspired by [re-frame-oidc](https://github.com/tafarij/re-frame-oidc).
+A wrapper for [oidc-client-ts](https://github.com/authts/oidc-client-ts) providing [OIDC](https://openid.net/specs/openid-connect-core-1_0.html) support for re-frame + reagent applications in cljs. Inspired by [re-frame-oidc](https://github.com/tafarij/re-frame-oidc).
 
 ## Overview
 
 Re-frame fx, event handlers and subscriptions are provided to allow interactive sign-in from an SPA without the need for a server backend.
+
+## Installation
+
+Add the following dependency to your deps.edn file:
+
+```clojure
+com.yetanalytics/re-oidc {:mvn/version "0.1.0"
+                          :exclusions  [io.github.cljsjs/oidc-client-ts
+                                        reagent/reagent
+                                        re-frame/re-frame]}
+```
+
+For production, you will need to add the following `cljsjs/oidc_client_ts.cljs` ClojureScript source:
+
+```clojure
+(ns cljsjs.oidc-client-ts
+  (:require [oidc-client-ts :as oidc]))
+
+(def UserManager oidc/UserManager)
+(def Log oidc/Log)
+(def WebStorageStateStore oidc/WebStorageStateStore)
+```
 
 ## Configuration
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
-{:deps    {org.clojure/clojure       {:mvn/version "1.10.0"}
-           org.clojure/clojurescript {:mvn/version "1.10.773"}
-           reagent/reagent           {:mvn/version "0.10.0"}
-           re-frame/re-frame         {:mvn/version "1.3.0-rc2"}
-           cljsjs/oidc-client        {:mvn/version "1.11.5-0"}}
+{:deps    {org.clojure/clojure             {:mvn/version "1.10.0"}
+           org.clojure/clojurescript       {:mvn/version "1.10.773"}
+           reagent/reagent                 {:mvn/version "0.10.0"}
+           re-frame/re-frame               {:mvn/version "1.3.0-rc2"}
+           io.github.cljsjs/oidc-client-ts {:mvn/version "2.0.1-1"}}
  :paths   ["src/lib" "resources"]
  :aliases {:dev   {:extra-deps
                    {org.clojure/test.check          {:mvn/version "1.1.1"}

--- a/src/lib/com/yetanalytics/re_oidc.cljs
+++ b/src/lib/com/yetanalytics/re_oidc.cljs
@@ -165,13 +165,16 @@
  (fn [{:keys [on-success
               on-failure
               query-string]}]
-   (let [on-failure (or on-failure
-                        [::add-error ::signin-redirect-callback-fx])
-         um (get-user-manager)]
-     (-> um
-         (.signinRedirectCallback query-string)
+   (let [on-failure   (or on-failure
+                          [::add-error ::signin-redirect-callback-fx])
+         user-manager (get-user-manager)
+         ;; We need a full URL, not query param string, here.
+         ;; See: PRs #535 and #999 on oidc-client-ts.
+         url-string   (str "http://127.0.0.1" query-string)]
+     (-> user-manager
+         (.signinRedirectCallback url-string)
          (u/handle-promise on-success on-failure)
-         (.then #(.clearStaleState um))))))
+         (.then #(.clearStaleState user-manager))))))
 
 (re-frame/reg-fx
  ::signout-redirect-fx

--- a/src/lib/com/yetanalytics/re_oidc.cljs
+++ b/src/lib/com/yetanalytics/re_oidc.cljs
@@ -99,8 +99,11 @@
    (swap! user-manager
           init!
           (assoc config
-                 "stateStore" (web-storage-state-store state-store)
-                 "userStore"  (web-storage-state-store user-store))
+                 ;; loadUserInfo is default true in original oidc-client lib,
+                 ;; false in new oidc-client-ts lib.
+                 "loadUserInfo" true
+                 "stateStore"   (web-storage-state-store state-store)
+                 "userStore"    (web-storage-state-store user-store))
           (select-keys init-input
                        [:on-user-loaded
                         :on-user-unloaded]))))

--- a/src/lib/com/yetanalytics/re_oidc.cljs
+++ b/src/lib/com/yetanalytics/re_oidc.cljs
@@ -193,17 +193,23 @@
          .signoutRedirectCallback
          (u/handle-promise on-success on-failure)))))
 
+(re-frame/reg-fx
+ ::print-error-fx
+ (fn [js-error]
+   (js/console.error js-error)))
+
 (defn add-error
   "Add a thrown error to the list in the db"
-  [db [_ handler-id js-error]]
-  (update db
-          :errors
-          (fnil conj [])
-          (u/js-error->clj
-           handler-id
-           js-error)))
+  [{:keys [db]} [_ handler-id js-error]]
+  {:db (update db
+               :errors
+               (fnil conj [])
+               (u/js-error->clj
+                handler-id
+                js-error))
+   :fx [[::print-error-fx js-error]]})
 
-(re-frame/reg-event-db
+(re-frame/reg-event-fx
  ::add-error
  add-error)
 

--- a/src/lib/com/yetanalytics/re_oidc.cljs
+++ b/src/lib/com/yetanalytics/re_oidc.cljs
@@ -220,27 +220,27 @@
 (defn user-loaded
   "Load a user object from js into the db and set status to :loaded"
   [db [_ js-user]]
-  (let [id-token (.-id_token js-user)
-        access-token (.-access_token js-user)
-        expires-at (.-expires_at js-user)
+  (let [id-token      (.-id_token js-user)
+        access-token  (.-access_token js-user)
+        expires-at    (.-expires_at js-user)
         refresh-token (.-refresh_token js-user)
-        token-type (.-token_type js-user)
-        state (.-state js-user)
+        token-type    (.-token_type js-user)
+        state         (.-state js-user)
         session-state (.-session_state js-user)
-        scope (.-scope js-user)
-        profile (js->clj (.-profile js-user))]
+        scope         (.-scope js-user)
+        profile       (js->clj (.-profile js-user))]
     (assoc db
            ::status :loaded
            ::user
-           {:id-token id-token
-            :access-token access-token
+           {:id-token      id-token
+            :access-token  access-token
             :refresh-token refresh-token
-            :expires-at expires-at
-            :token-type token-type
-            :state state
-            :scope scope
+            :expires-at    expires-at
+            :token-type    token-type
+            :state         state
+            :scope         scope
             :session-state session-state
-            :profile profile})))
+            :profile       profile})))
 
 (re-frame/reg-event-db
  ::user-loaded
@@ -368,26 +368,26 @@
              (dissoc ::callback
                      ::login-query-string))
      :fx [[::init-fx
-           {:config (cond-> oidc-config
-                      redirect-uri-absolution
-                      u/absolve-redirect-uris)
-            :state-store state-store
-            :user-store user-store
-            :on-user-loaded on-user-loaded
+           {:config           (cond-> oidc-config
+                                redirect-uri-absolution
+                                u/absolve-redirect-uris)
+            :state-store      state-store
+            :user-store       user-store
+            :on-user-loaded   on-user-loaded
             :on-user-unloaded on-user-unloaded}]
           (case ?callback
             :login [::signin-redirect-callback-fx
                     {:query-string ?qstring
-                     :on-success on-login-success
-                     :on-failure on-login-failure}]
+                     :on-success   on-login-success
+                     :on-failure   on-login-failure}]
             :logout [::signout-redirect-callback-fx
                      {:on-success on-logout-success
                       :on-failure on-logout-failure}]
             [::get-user-fx
              ;; We need to set the user, if present, no matter what
-             {:auto-login auto-login
-              :on-success on-get-user-success
-              :on-failure on-get-user-failure
+             {:auto-login     auto-login
+              :on-success     on-get-user-success
+              :on-failure     on-get-user-failure
               :on-user-loaded on-user-loaded}])]}))
 
 (re-frame/reg-event-fx

--- a/src/lib/com/yetanalytics/re_oidc.cljs
+++ b/src/lib/com/yetanalytics/re_oidc.cljs
@@ -133,12 +133,9 @@
          .getUser
          (u/handle-promise
           (cond-> (fn [?user]
-                    (if-let [logged-in-user (and ?user
-                                                 (not
-                                                  (some-> ?user
-                                                          .-expires_at
-                                                          u/expired?))
-                                                 ?user)]
+                    (if-let [logged-in-user
+                             (and ?user
+                                  (not (some-> ?user .-expires_at u/expired?)))]
                       (do
                         (re-frame/dispatch [::user-loaded logged-in-user])
                         ;; ensure any custom loaded callback is fired

--- a/src/lib/com/yetanalytics/re_oidc.cljs
+++ b/src/lib/com/yetanalytics/re_oidc.cljs
@@ -77,6 +77,17 @@
     (doto (UserManager. (clj->js config))
       (reg-events! lifecycle-callbacks))))
 
+(defn- web-storage-state-store
+  [store]
+  (let [store* (case store
+                 :local-storage
+                 js/window.localStorage
+                 :session-storage
+                 js/window.sessionStorage
+                 ;; custom
+                 store)]
+    (new WebStorageStateStore #js {:store store*})))
+
 (re-frame/reg-fx
  ::init-fx
  (fn [{:keys [config
@@ -87,26 +98,9 @@
        :as init-input}]
    (swap! user-manager
           init!
-          (assoc
-           config
-           "stateStore"
-           (new WebStorageStateStore
-                #js {:store (case state-store
-                              :local-storage
-                              js/window.localStorage
-                              :session-storage
-                              js/window.sessionStorage
-                              ;; custom
-                              state-store)})
-           "userStore"
-           (new WebStorageStateStore
-                #js {:store (case user-store
-                              :local-storage
-                              js/window.localStorage
-                              :session-storage
-                              js/window.sessionStorage
-                              ;; custom
-                              user-store)}))
+          (assoc config
+                 "stateStore" (web-storage-state-store state-store)
+                 "userStore"  (web-storage-state-store user-store))
           (select-keys init-input
                        [:on-user-loaded
                         :on-user-unloaded]))))

--- a/src/lib/com/yetanalytics/re_oidc.cljs
+++ b/src/lib/com/yetanalytics/re_oidc.cljs
@@ -1,5 +1,5 @@
 (ns com.yetanalytics.re-oidc
-  (:require [cljsjs.oidc-client :refer [UserManager Log WebStorageStateStore]]
+  (:require [cljsjs.oidc-client-ts :refer [UserManager Log WebStorageStateStore]]
             [re-frame.core :as re-frame]
             [clojure.spec.alpha :as s :include-macros true]
             [com.yetanalytics.re-oidc.user :as user]

--- a/src/lib/com/yetanalytics/re_oidc.cljs
+++ b/src/lib/com/yetanalytics/re_oidc.cljs
@@ -1,4 +1,5 @@
 (ns com.yetanalytics.re-oidc
+  #_{:clj-kondo/ignore [:unused-referred-var]} ; For Log
   (:require [cljsjs.oidc-client-ts :refer [UserManager Log WebStorageStateStore]]
             [re-frame.core :as re-frame]
             [clojure.spec.alpha :as s :include-macros true]

--- a/src/test/com/test_runner.cljs
+++ b/src/test/com/test_runner.cljs
@@ -5,5 +5,5 @@
     [com.yetanalytics.re-oidc-test]
     [figwheel.main.testing :refer [run-tests-async]]))
 
-(defn -main [& args]
+(defn -main [& _args]
   (run-tests-async 5000))

--- a/src/test/com/yetanalytics/re_oidc_test.cljs
+++ b/src/test/com/yetanalytics/re_oidc_test.cljs
@@ -16,12 +16,12 @@
                       :message "whoops!",
                       :handler :some-handler,
                       :ex-data {:type :com.yetanalytics.re-oidc-test/whoops}}]}
-           (add-error
-            {}
-            [nil
-             :some-handler
-             (ex-info "whoops!"
-                      {:type ::whoops})])))))
+           (:db (add-error
+                 {:db {}}
+                 [nil
+                  :some-handler
+                  (ex-info "whoops!"
+                           {:type ::whoops})]))))))
 
 (deftest user-loaded-test
   (testing "Loads the user from JS"

--- a/test.cljs.edn
+++ b/test.cljs.edn
@@ -5,6 +5,13 @@
 
   ;; uncomment to launch tests in a headless environment
   ;; you will have to figure out the path to chrome on your system
-  :launch-js ["chromium" "--headless=new" "--disable-gpu" "--repl" :open-url]
+  :launch-js ["chromium"
+              "--headless=new"
+              "--disable-gpu"
+              "--no-sandbox"
+              "--disable-setuid-sandbox"
+              "--password-store=basic"
+              "--user-data-dir=/tmp/chromium"
+              "--repl" :open-url]
   }
 {:main com.test-runner}


### PR DESCRIPTION
The oidc-client(-js) library [has been archived](https://github.com/IdentityModel/oidc-client-js?tab=readme-ov-file#no-longer-maintained) and superseded by the [oidc-client-ts](https://github.com/authts/oidc-client-ts) library, so we update to the latest cljsjs-supported version. In addition, log `::add-error` errors, perform minor refactors, and update GitHub Actions workflows.

**Note:** Make sure to replace `cljsjs/oidc-client` with `io.github.cljsjs/oidc-client-ts` in your `:exclusions` list for this library.